### PR TITLE
Code quality improvements - squid:S00115, squid:S106, squid:S1213

### DIFF
--- a/src/main/java/org/jocl/Sizeof.java
+++ b/src/main/java/org/jocl/Sizeof.java
@@ -28,11 +28,21 @@
 package org.jocl;
 
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Size constants for scalar and vector data types.
  */
 public final class Sizeof 
 {
+
+    /**
+     * The logger used in this class
+     */
+    private static final Logger logger =
+            Logger.getLogger(Sizeof.class.getName());
+
     static
     {
         CL.loadNativeLibrary();
@@ -349,9 +359,8 @@ public final class Sizeof
      * Size of a cl_sampler, in bytes
      */
     public static final int cl_sampler = POINTER;
-    
 
-    
+
     /**
      * Computes the size of a pointer, in bytes
      * 
@@ -379,16 +388,8 @@ public final class Sizeof
         {
             return 8;
         }
-        System.err.println(
-            "Unknown value for sun.arch.data.model - assuming 32 bits");
+        logger.log(Level.SEVERE, "Unknown value for sun.arch.data.model - assuming 32 bits");
         return 4;
     }
     private static native int computePointerSizeNative();
-
-    /**
-     * Private constructor to prevent instantiation
-     */
-    private Sizeof()
-    {
-    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00115 - Constant names should comply with a naming convention.
squid:S106 - Standard outputs should not be used directly to log anything.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes technical debt of 135 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S106
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava