### PR TITLE
solves CXXABI_1.3.8 not found on ubuntu14 and centos7

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ virtual machine. Type
     
 to open an ssh connection to the virtual machine, and 
     
-    cp /tmp/JOCL/target/*.jar /vagrant/
+    # vagrant plugin install vagrant-scp
+    vagrant scp default:/tmp/JOCL/target/*.jar .
     
 to copy the JAR files into the working directory of the host machine.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,43 +1,24 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "centos/7"
   config.vm.provider "virtualbox" do |vb|
     # Customize the amount of memory on the VM:
     vb.memory = "2048"
     vb.cpus = 2
   end
 
-  config.vm.provision "shell", inline: <<-SHELL
-    apt-get update -qq
-    apt-get install -yqq software-properties-common \
-                         build-essential \
-                         cmake \
-                         cmake-data \
-                         cmake-extras \
-                         git \
-                         maven
-    add-apt-repository ppa:webupd8team/java -y
-    apt-get update -qq
-    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-    apt-get install -yqq oracle-java8-installer oracle-java8-set-default 
-    bash /etc/profile.d/jdk.sh
-    apt-get install -yqq ocl-icd-libopencl1 \
-                         opencl-headers \
-                         clinfo \
-                         ocl-icd-opencl-dev \
-                         beignet-opencl-icd \
-                         mesa-opencl-icd \
-                         opencl-headers
-    apt-get install libgl1-mesa-dev
-    cd /tmp
-    git clone https://github.com/gpu/JOCL
-    git clone https://github.com/gpu/JOCLCommon
-    ln -s /usr/lib/jvm/java-8-oracle /usr/lib/jvm/java
-    cmake JOCL
-    sudo make
-    cd JOCL
-    mvn clean package -DskipTests
-  SHELL
+
+config.vm.provision "shell", inline: <<-SHELL
+curl http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm >epel-release-latest-7.noarch.rpm
+rpm -ivh epel-release-latest-7.noarch.rpm
+
+yum install -y cmake3 gcc-c++ git maven mesa-libGL-devel ocl-icd-devel 
+cd /tmp
+git clone https://github.com/gpu/JOCL
+git clone https://github.com/gpu/JOCLCommon
+export JAVA_HOME=/etc/alternatives/java_sdk
+cmake3 JOCL
+make
+cd JOCL
+mvn clean package -DskipTests
+SHELL
 end


### PR DESCRIPTION
since linux jocl library is built on `ubuntu/xenial` it uses newer cxxabi, when i am trying to run my code on centos7 or ubuntu14 which do not have cxxabi1.3.8 i get this:

```
java.lang.UnsatisfiedLinkError: /tmp/libJOCL_2_0_0-linux-x86_64.so: /lib64/libstdc++.so.6: version `CXXABI_1.3.8' not found (required by /tmp/libJOCL_2_0_0-linux-x86_64.so)
        at java.lang.ClassLoader$NativeLibrary.load(Native Method)
        at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
        at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1824)
        at java.lang.Runtime.load0(Runtime.java:809)
        at java.lang.System.load(System.java:1086)
        at org.jocl.LibUtils.loadLibraryResource(LibUtils.java:269)
        at org.jocl.LibUtils.loadLibrary(LibUtils.java:151)
        at org.jocl.CL.loadNativeLibrary(CL.java:65)
        at org.jocl.CL.<clinit>(CL.java:51)
```

this PR solves this problem by running vagrant build on centos7