### PR TITLE
Make nativePointer readable from the outside

### DIFF
--- a/src/main/java/org/jocl/NativePointerObject.java
+++ b/src/main/java/org/jocl/NativePointerObject.java
@@ -120,12 +120,13 @@ public class NativePointerObject
         this.byteOffset += byteOffset;
     }
 
-    
-    
     /**
-     * Public method to obtain the native
-     * pointer value.
-     * 
+     * Method to obtain the native pointer value.
+     *
+     * Clients should usually not use this pointer value directly.
+     * It is only intended for interoperability with other JNI based
+     * libraries.
+     *
      * @return The native pointer value
      */
     public long getNativePointer()

--- a/src/main/java/org/jocl/NativePointerObject.java
+++ b/src/main/java/org/jocl/NativePointerObject.java
@@ -123,7 +123,7 @@ public class NativePointerObject
     
     
     /**
-     * Package-private method to obtain the native
+     * Public method to obtain the native
      * pointer value.
      * 
      * @return The native pointer value

--- a/src/main/java/org/jocl/NativePointerObject.java
+++ b/src/main/java/org/jocl/NativePointerObject.java
@@ -128,7 +128,7 @@ public class NativePointerObject
      * 
      * @return The native pointer value
      */
-    protected long getNativePointer()
+    public long getNativePointer()
     {
         return nativePointer;
     }


### PR DESCRIPTION
Dear @gpu ,

we (CC @bnorthan) recently came across the issue that we cannot access the nativePointer inside the NativePointerObject class. However, this would be very useful to bridge towards other OpenCL-libraries as discussed here:
https://forum.image.sc/t/high-performance-fft-based-algorithms-deconvolution/31710/38

Would you mind merging this PR and deploying a new JOCL?

Thanks a lot in advance!

Cheers,
Robert
