### PR TITLE
Load arm64 library on aarch64 arch

### DIFF
--- a/src/main/java/org/jocl/LibUtils.java
+++ b/src/main/java/org/jocl/LibUtils.java
@@ -591,7 +591,7 @@ public final class LibUtils
         {
             return ArchType.X86_64;
         }
-        if (osArch.startsWith("arm64"))
+        if (osArch.startsWith("arm64") || osArch.equals("aarch64"))
         {
             return ArchType.ARM64;
         }


### PR DESCRIPTION
Java has two 64-bit arm ports, `arm64` and `aarch64`, with newer Java versions having only `aarch64` - https://openjdk.java.net/jeps/340
In particular, the new Zulu VM builds running on the new Apple M1s use `aarch64`, so currently arch detection on them fails. 