### PR TITLE
pocl: add libpocl.so to search path on android

### DIFF
--- a/src/main/java/org/jocl/LibInitializer.java
+++ b/src/main/java/org/jocl/LibInitializer.java
@@ -101,6 +101,7 @@ class LibInitializer
         {
             return new String[]
             {
+                "libpocl.so", // portablecl.org
                 "/system/vendor/lib/libOpenCL.so", // Qualcomm
                 "/system/vendor/lib/egl/libGLES_mali.so", // ARM MALI SDK
                 "/system/vendor/lib/libPVROCL.so", // PowerVR SDK


### PR DESCRIPTION
Hi,

We recently made a reference app for Android ([link](https://github.com/cpc/PoCL-R-Reference-Android-Java-Client)) that uses JOCL and our OpenCL implementation and added a new library to look for on Android only.