### PR TITLE
Ensure finding the OpenCL library on standard Linux Installation

### DIFF
--- a/src/main/java/org/jocl/LibInitializer.java
+++ b/src/main/java/org/jocl/LibInitializer.java
@@ -111,6 +111,14 @@ class LibInitializer
                 defaultLibName
             };
         }
+        if (OSType.LINUX.equals(osType))
+        {
+            return new String[]
+            {
+                "libOpenCL.so.1",
+                defaultLibName
+            };
+        }
         return new String[]
         {
             defaultLibName


### PR DESCRIPTION
Thank you for providing this awesome library. The JOCL library is super helpful for processing large microscopy images in biological and medical research. It is used by many plugins for the [FIJI image analysis software](https://fiji.sc) for example: https://clij.github.io/ and https://imagej.net/plugins/labkit/

I noticed that the JOCL library would not work on fresh Linux installations. JOCL would not find the OpenCL library despite GPU drivers and OpenCL being properly installed. The problem can be fixed by installing the development bindings for libOpenCL. However dev binding should usually not be required in a runtime environment.

Debugging the problem I found that JOCL searches for a file called "libOpenCL.so" which is only installed with the dev bindings. A standard installation of the OpenCL library would have binaries called:
- "libOpenCL.so.1.0.0"
- "libOpenCL.so.1"        (this is a link to the first file)
They have these additional version suffixes to avoid version conflicts.

This PR changes JOCL to find and load "libOpenCL.so.1" on Linux.

This means that JOCL can now run on Linux without requiring the explicit installation of dev bindings.
Tested on Ubuntu 24.04